### PR TITLE
Fix imports

### DIFF
--- a/identification_arx.ipynb
+++ b/identification_arx.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Plots\")"
    ]
   },
   {

--- a/identification_impulse_response.ipynb
+++ b/identification_impulse_response.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Plots\")"
    ]
   },
   {

--- a/identification_statespace.ipynb
+++ b/identification_statespace.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Pkg; Pkg.add(\"https://github.com/baggepinnen/ControlSystemIdentification.jl\"); Pkg.add(\"Optim\"); Pkg.add(\"Plots\")"
+    "using Pkg; Pkg.add(\"ControlSystemIdentification\"); Pkg.add(\"Optim\"); Pkg.add(\"Plots\")"
    ]
   },
   {


### PR DESCRIPTION
The github url imports of ControlSystemIdentification in many of the notebooks are broken:
```
LoadError: `https://github.com/baggepinnen/ControlSystemIdentification.jl` is not a valid package name
The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.
```

This PR changes them to regular imports. An alternative would be to keep them as urls and use the correct syntax as described in the error above.